### PR TITLE
always write out values, even if they are the default

### DIFF
--- a/download.php
+++ b/download.php
@@ -26,9 +26,7 @@ $layers = array();
 // Find the differences between the default map and the user's map
 foreach ( $map->matrix as $i => $key ) {
 	foreach ( $key->layers as $l => $layer ) {
-		if ( $default[$i]->layers->{0}->key != $layer->key ) {
-			$layers[$l][$default[$i]->layers->{0}->key] = $layer->key;
-		}
+		$layers[$l][$default[$i]->layers->{0}->key] = $layer->key;
 	}
 }
 


### PR DESCRIPTION
we need to write out values even if they are the default keybinding in the map

this is because a lower layer can overwrite the default, and setting a value back to default in a higher layer will not work.

a fancier version of this can check if the user's lower layers match the key being written out to the current layer, but i think it's just fine to write out all assignments. maybe kll should support the optimization if it's a big deal, but probably not the configurator

here's the json of the layout i saw this issue with: http://pastebin.com/4Yw689xR