### PR TITLE
Fixes Regression in Download Firmware

### DIFF
--- a/download.php
+++ b/download.php
@@ -92,7 +92,7 @@ file_put_contents( $path, json_encode( $map, JSON_PRETTY_PRINT ) );
 
 // Run compilation, very simple, 1 layer per entry (script supports complicated entries)
 $log_file = $objpath . '/build.log';
-$cmd = 'cgi-bin/build_layout.bash ' . $md5sum . ' ' . $name . ' ';
+$cmd = 'cgi-bin/build_layout.bash ' . $md5sum . $uid . ' ' . $name . ' ';
 for ( $c = 0; $c <= $max_layer; $c++ ) {
 	$path = $objpath . '/' . $files[$c]['name'];
 	file_put_contents( $path, $files[$c]['content'] ); // Write kll file


### PR DESCRIPTION
This resolves #31 and passes the new `uid` string appened to the md5 hash to the
build script to keep all artifacts in the same directory.