### PR TITLE
Added APP key to standard group to display by default

### DIFF
--- a/js/defaults.js
+++ b/js/defaults.js
@@ -144,11 +144,10 @@ APP.keyDefaults = {
 'LANG8': { y: 0, x: 0, w: 4, h: 4, group: 'international' },
 'LANG9': { y: 0, x: 0, w: 4, h: 4, group: 'international' },
 
-'APP': { y: 0, x: 0, w: 4, h: 4 },
-
 'EXEC': { y: 0, x: 0, w: 4, h: 4 },
 'HELP': { y: 0, x: 0, w: 4, h: 4 },
 'MENU': { y: 0, x: 0, w: 4, h: 4, group: 'standard' },
+'APP': { y: 0, x: 0, w: 4, h: 4, group: 'standard' },
 'SELECT': { y: 0, x: 0, w: 4, h: 4 },
 'STOP': { y: 0, x: 0, w: 4, h: 4 },
 'AGAIN': { y: 0, x: 0, w: 4, h: 4 },


### PR DESCRIPTION
The APP key is the key that opens the context menu, I added it to the standard group and changed the order to display the option after the MENU key.