### PR TITLE
Use right number of ledControl params

### DIFF
--- a/js/defaults.js
+++ b/js/defaults.js
@@ -550,9 +550,9 @@ var DEFAULTS = (function (def) {
             'LAT16': {y: 28, x: 60, w: 4, h: 4, label: 'LATCH-16'},
             'LATCH16': {y: 28, x: 60, w: 4, h: 4, label: 'LATCH-16'},
 
-            '#:ledControl( 3, 15, 0 )': {y: 28, x: 0, w: 4, h: 4, label: 'LED-', group: 'special'},
-            '#:ledControl( 4, 15, 0 )': {y: 28, x: 0, w: 4, h: 4, label: 'LED+', group: 'special'},
-            '#:ledControl( 5, 0, 0 )': {y: 28, x: 0, w: 4, h: 4, label: 'LED OFF', group: 'special'},
+            '#:ledControl( 3, 15 )': {y: 28, x: 0, w: 4, h: 4, label: 'LED-', group: 'special'},
+            '#:ledControl( 4, 15 )': {y: 28, x: 0, w: 4, h: 4, label: 'LED+', group: 'special'},
+            '#:ledControl( 5, 0 )': {y: 28, x: 0, w: 4, h: 4, label: 'LED OFF', group: 'special'},
 
             '#:flashMode()': {y: 28, x: 0, w: 4, h: 4, label: 'FLASH', group: 'special'},
             '#:toggleKbdProtocol()': {y: 28, x: 0, w: 4, h: 4, label: '6/N-KRO', group: 'special'},


### PR DESCRIPTION
If you use the configurator and add one key to `NONE`. It will generate:
```
Name = "MDErgo1";
Layout = "Default";
Base = "Blank";
Version = "0.1";
Author = "HaaTa (Jacob Alexander) 2015";
KLL = "0.3c";
Date = "2015-09-12";
Generator = "KIICONF 0.2";

U"FUNCTION1" : None;
```

The problem is, this kll is not valid. If you try to build a
kiibohd.dfu.bin file. It will raise an error :
```
-- Build files have been written to: /Users/ben/code/controller/Keyboards/darwin16.miami_ergodox_r.gcc.make
[  3%] Generating KLL Layout
kll BETA 0.5c.54d839fa7a8dcd4352da10288512036a54e247dc - 2017-10-21 16:11:42 +0200
ERROR: incorrect number of arguments for ledControl(3,15,0). Expected 2 Got 3
  ledControl <= LED_control_capability(mode:1,amount:1);
Traceback (most recent call last):
  File "../../kll/kll", line 159, in <module>
    control.process()
  File "/Users/ben/code/controller/kll/common/stage.py", line 123, in process
    stage.process()
  File "/Users/ben/code/controller/kll/common/stage.py", line 2827, in process
    self.emitter.process()
  File "/Users/ben/code/controller/kll/emitters/kiibohd/kiibohd.py", line 671, in process
    self.fill_dict['ResultMacros'] += "{0}, ".format(self.result_combo_conversion(combo))
  File "/Users/ben/code/controller/kll/emitters/kiibohd/kiibohd.py", line 252, in result_combo_conversion
    if identifier.total_arg_bytes(self.capabilities.data) > 0:
  File "/Users/ben/code/controller/kll/common/id.py", line 560, in total_arg_bytes
    raise AssertionError("Invalid arguments")
AssertionError: Invalid arguments
make[2]: *** [generatedKeymap.h] Error 1
make[1]: *** [CMakeFiles/kiibohd.dir/all] Error 2
make: *** [all] Error 2
Error in make. Exiting...
```